### PR TITLE
Add publish to WinGet workflow

### DIFF
--- a/.github/workflows/publish-to-winget.yml
+++ b/.github/workflows/publish-to-winget.yml
@@ -1,0 +1,22 @@
+name: Publish to WinGet
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Get version
+        id: get-version
+        run: |
+          # Finding the version from release tag name
+          $VERSION="${{ github.event.release.tag_name }}" -replace '^v?((?:\d+\.)+\d+)$','$1' -replace '^((?:\d+\.){2}\d+)$', '$1.0'
+          echo "::set-output name=version::$VERSION"
+        shell: pwsh
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Timthreetwelve.WUView
+          version: ${{ steps.get-version.outputs.version }}
+          token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This PR automates the release of new versions in Windows Package Manager. For the WinGet Releaser (GitHub Action) (https://github.com/marketplace/actions/winget-releaser) to work, you, @Timthreetwelve, must create a GitHub token with the public_repo scope and store it in a repository secret called `WINGET_TOKEN` which is then used by the workflow.