### PR TITLE
Add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,11 @@ updates:
       interval: "weekly"
       day: "saturday"
     open-pull-requests-limit: 5
+  - package-ecosystem: "nuget"
+    directory: "/WUView"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 25
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "saturday"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
This PR adds Dependabot to the repository. To enable it, the steps described in the documentation must be followed (see [link](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuring-dependabot-version-updates#enabling-dependabot-version-updates)). Currently it is configured to ignore all major version updates for NuGet packages.