### PR TITLE
Update language files

### DIFF
--- a/WUView/Languages/Strings.ca-ES.xaml
+++ b/WUView/Languages/Strings.ca-ES.xaml
@@ -15,7 +15,7 @@
 
         Translation contributed by:  @Timthreetwelve & Google Translate
 
-        Date last update:            2024/10/20
+        Date last update:            2026/07/29
 
         ======================================================================
     -->
@@ -39,6 +39,8 @@
     <sys:String x:Key="About_LicenseText">Aquest projecte té llicència sota els termes de la llicència MIT.</sys:String>
     <sys:String x:Key="About_LicenseToolTip">Consulta el document de la llicència</sys:String>
     <sys:String x:Key="About_Translations">Traduccions</sys:String>
+    <sys:String x:Key="About_UpdateFound">Hi ha disponible una versió més recent</sys:String>
+    <sys:String x:Key="About_UpdateFoundTooltip">Feu clic per anar a la pàgina de versions de GitHub</sys:String>
     <sys:String x:Key="About_UpdateWU">Actualitza WUView</sys:String>
     <sys:String x:Key="About_UpdateWUText">Comproveu si hi ha una nova versió de Windows Update Viewer</sys:String>
     <sys:String x:Key="About_UpdateWUToolTip">Consulteu GitHub per obtenir una versió més recent</sys:String>
@@ -47,7 +49,7 @@
     <sys:String x:Key="Button_Cancel">Cancel·lar</sys:String>
     <sys:String x:Key="Button_CheckUpdate">Comprova si hi ha actualitzacions</sys:String>
     <sys:String x:Key="Button_Close">Tanca aquest menú</sys:String>
-    <sys:String x:Key="Button_CompareLanguageToolTip">Feu clic per comparar l'idioma actual amb el predeterminat (en-US). Els resultats s'escriuen al fitxer de registre.</sys:String>
+    <sys:String x:Key="Button_CompareLanguageToolTip" xml:space="preserve">Feu clic per comparar l'idioma actual amb el predeterminat (en-US).&#x0a;Els resultats s'escriuen al fitxer de registre.</sys:String>
     <sys:String x:Key="Button_ExportSettings">Configuració d'exportació</sys:String>
     <sys:String x:Key="Button_ExportSettingsToolTip">Exporta la configuració actual a un fitxer.</sys:String>
     <sys:String x:Key="Button_ImportSettings">Configuració d'importació</sys:String>
@@ -108,7 +110,7 @@
     <sys:String x:Key="MsgText_AllUpdatesExcluded">S'han exclòs totes les actualitzacions que es poden mostrar.</sys:String>
     <sys:String x:Key="MsgText_ApplicationShutdown">s'està tancant</sys:String>
     <sys:String x:Key="MsgText_ApplicationStarting">està en marxa</sys:String>
-    <sys:String x:Key="MsgText_AppUpdateCheckFailed">No s'ha pogut comprovar l'actualització.</sys:String>
+    <sys:String x:Key="MsgText_AppUpdateCheckFailed" xml:space="preserve">No s'ha pogut comprovar l'actualització.&#x0a;Consulteu el fitxer de registre per obtenir més informació.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateChecking">S'està comprovant l'actualització.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateClose">Si feu clic a "Sí", es tancarà el visor de Windows Update.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateGoToRelease">Vols anar a la pàgina de llançament?</sys:String>
@@ -122,11 +124,13 @@
     <sys:String x:Key="MsgText_ElapsedTime">Temps transcorregut</sys:String>
     <sys:String x:Key="MsgText_Error_TestLanguage">Hi ha un problema amb el fitxer d'idioma.</sys:String>
     <sys:String x:Key="MsgText_ErrorCaption">ERROR</sys:String>
+    <sys:String x:Key="MsgText_ErrorGeneral">S'ha produït un error.</sys:String>
     <sys:String x:Key="MsgText_ErrorOpeningFile">S'ha produït un error en obrir {0}</sys:String>
     <sys:String x:Key="MsgText_ErrorReadingFile">S'ha produït un error en llegir {0}</sys:String>
     <sys:String x:Key="MsgText_ErrorExportingSettings">S'ha produït un error en exportar el fitxer de configuració.</sys:String>
     <sys:String x:Key="MsgText_ErrorImportingSettings">S'ha produït un error en importar el fitxer de configuració.</sys:String>
     <sys:String x:Key="MsgText_ErrorSavingSettings">S'ha produït un error en desar el fitxer de configuració.</sys:String>
+    <sys:String x:Key="MsgText_ErrorSeeLog">Consulteu el fitxer de registre per obtenir més informació.</sys:String>
     <sys:String x:Key="MsgText_EventLogNA">No s'han trobat registres d'esdeveniments per a aquesta actualització.</sys:String>
     <sys:String x:Key="MsgText_EventLogNoRecords">No s'ha trobat cap registre d'esdeveniments que contingui "{0}".</sys:String>
     <sys:String x:Key="MsgText_ExcludingContaining">S'exclouen les actualitzacions que continguin:</sys:String>
@@ -173,9 +177,11 @@
     <sys:String x:Key="SettingsSubHead_UISettings">Tema, color d'accent, mida de la IU, alçada de fila, posició inicial i molt més</sys:String>
     <!--  Settings Page Items  -->
     <sys:String x:Key="SettingsItem_AccentColor">Color d'accent</sys:String>
+    <sys:String x:Key="SettingsItem_AutoUpdateCheck">Comprova automàticament si hi ha una versió més recent quan s'obre la pàgina Sobre</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Si canvieu d'idioma, l'aplicació es reiniciarà!</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Format de data de quadrícula</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Tipus de lletra</sys:String>
+    <sys:String x:Key="SettingsItem_DisplayFontSize">Mida de la lletra</sys:String>
     <sys:String x:Key="SettingsItem_EditExcludeToolTip">Maj+Feu clic per obrir el fitxer amb l'aplicació predeterminada</sys:String>
     <sys:String x:Key="SettingsItem_EditSettingsWarning">Qualsevol canvi fet al fitxer de configuració mentre l'aplicació s'executa es sobreescriurà!</sys:String>
     <sys:String x:Key="SettingsItem_EnableLanguageTesting">Habilitar les proves d'idioma</sys:String>
@@ -197,7 +203,7 @@
     <sys:String x:Key="SettingsItem_StartCentered">Comenceu amb la finestra centrada a la pantalla</sys:String>
     <sys:String x:Key="SettingsItem_Theme">Tema</sys:String>
     <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Representa el nombre de cadenes en l'idioma actual en comparació amb el predeterminat (en-US).</sys:String>
-    <sys:String x:Key="SettingsItem_TranslationToolTipLine2">Premeu Ctrl+Maj+K o feu clic al botó Comparar per comparar fitxers d'idioma. Els resultats s'escriuen al fitxer de registre.</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine2" xml:space="preserve">Premeu Ctrl+Maj+K per comparar fitxers d'idioma.&#x0a;Els resultats s'escriuen al fitxer de registre.</sys:String>
     <sys:String x:Key="SettingsItem_UISize">Mida de la IU</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageCheckBox">Utilitzeu l'idioma de visualització de Windows</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageToolTipLine1">Quan se selecciona aquesta opció, s'utilitzarà l'idioma especificat a la configuració de Windows.</sys:String>
@@ -248,45 +254,5 @@
     <sys:String x:Key="SettingsEnum_DateFormat_RegionalDateTime">Regional: data i hora</sys:String>
 
 </ResourceDictionary>
-
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    LANGUAGE FILE UPDATES
-
-    Additions, Deletions and Updates will be made in the appropriate sections above. Each change will
-    be associated with a comment made below this block.
-
-    Comment Format:
-       There will be a header indicating when the change was made (date yyyy/mm/dd and UTC time).
-       Modified lines will follow, one comment line per line changed.
-       Comment lines use this syntax:  Change Type | Key Name
-
-     Change type:
-       A = Added
-       D = Deleted
-       U = Updated
-       * = Comment not related to a single line
-     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-    <!-- Begin changes on 2023/11/15 @ 18:55 UTC -->
-    <!-- U | About_Contribute -->
-    <!-- U | About_ContributeToolTip -->
-    <!-- A | About_GitHub -->
-    <!-- A | Button_Close -->
-    <!-- U | Button_No -->
-    <!-- U | Button_OpenAppFolder -->
-    <!-- U | Button_Yes -->
-    <!-- U | MenuItem_SaveJSON -->
-    <!-- U | MsgText_Error_TestLanguage -->
-    <!-- U | OperationType_Installation -->
-    <!-- U | OperationType_Uninstallation -->
-    <!-- U | ResultCode_Failed -->
-    <!-- U | ResultCode_InProgress -->
-    <!-- U | ResultCode_NotStarted -->
-    <!-- U | ResultCode_Aborted -->
-    <!-- U | ResultCode_Succeeded -->
-    <!-- U | ResultCode_SucceededWithErrors -->
-    <!-- U | SettingsItem_EnableLanguageTesting -->
-    <!-- U | SettingsItem_UseOSLanguageToolTipLine1 -->
-    <!-- U | SettingsItem_UseOSLanguageToolTipLine1 -->
-    <!-- A | SettingsSubHead_Language -->
-    <!-- End of changes on 2023/11/15 -->
+    
+<!-- See Strings.en-US for change history -->

--- a/WUView/Languages/Strings.en-US.xaml
+++ b/WUView/Languages/Strings.en-US.xaml
@@ -11,14 +11,13 @@
 
         Application name:            Windows Update Viewer
 
-        Language name:
+        Language name:               English (en-US)
 
-        Translation contributed by:
+        Translation contributed by:  Timthreetwelve
 
-        Date last update:
+        Date last update:            See the change log section below.
 
         ========================================================================
-
     -->
 
     <!--  About Page  -->
@@ -50,7 +49,7 @@
     <sys:String x:Key="Button_Cancel">Cancel</sys:String>
     <sys:String x:Key="Button_CheckUpdate">Check for Update</sys:String>
     <sys:String x:Key="Button_Close">Close Menu</sys:String>
-    <sys:String x:Key="Button_CompareLanguageToolTip">Click to compare current language to the default (en-US). Results are written to the log file.</sys:String>
+    <sys:String x:Key="Button_CompareLanguageToolTip" xml:space="preserve">Click to compare current language to the default (en-US).&#x0a;Results are written to the log file.</sys:String>
     <sys:String x:Key="Button_ExportSettings">Export Settings</sys:String>
     <sys:String x:Key="Button_ExportSettingsToolTip">Export current settings to a file.</sys:String>
     <sys:String x:Key="Button_ImportSettings">Import Settings</sys:String>
@@ -111,7 +110,7 @@
     <sys:String x:Key="MsgText_AllUpdatesExcluded">All displayable updates have been excluded.</sys:String>
     <sys:String x:Key="MsgText_ApplicationShutdown">is shutting down</sys:String>
     <sys:String x:Key="MsgText_ApplicationStarting">is starting up</sys:String>
-    <sys:String x:Key="MsgText_AppUpdateCheckFailed">Check for update failed. See the log for more information.</sys:String>
+    <sys:String x:Key="MsgText_AppUpdateCheckFailed" xml:space="preserve">Check for update failed.&#x0a;See the log for more information.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateChecking">Checking for update.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateClose">Clicking 'Yes' will close Windows Update Viewer.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateGoToRelease">Do you want to go to the release page?</sys:String>
@@ -204,7 +203,7 @@
     <sys:String x:Key="SettingsItem_StartCentered">Start with window centered on screen</sys:String>
     <sys:String x:Key="SettingsItem_Theme">Theme</sys:String>
     <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Represents the number of strings in the current language compared to the default (en-US).</sys:String>
-    <sys:String x:Key="SettingsItem_TranslationToolTipLine2">Press Ctrl+Shift+K or click compare button to compare language files. Results are written to the log file.</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine2" xml:space="preserve">Press Ctrl+Shift+K to compare language files.&#x0a;Results are written to the log file.</sys:String>
     <sys:String x:Key="SettingsItem_UISize">UI Size</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageCheckBox">Use Windows display language</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageToolTipLine1">When this option is selected, the language specified in the Windows settings will</sys:String>
@@ -363,4 +362,11 @@
     <!-- Begin changes on 2026/07/08 @ 16:00 UTC -->
     <!-- U | About_BuildDate - Changed 'Build' to 'Commit' -->
     <!-- End of changes on 2026/07/08 @ 16:00 UTC -->
+
+    <!-- Begin changes on 2026/07/29 @ 18:00 UTC -->
+    <!-- U | Button_CompareLanguageToolTip        - Added xml:space="preserve" and line break character &#x0a; -->
+    <!-- U | MsgText_AppUpdateCheckFailed         - Added xml:space="preserve" and line break character &#x0a; -->
+    <!-- U | SettingsItem_TranslationToolTipLine2 - Added xml:space="preserve" and line break character &#x0a; -->
+    <!-- End of changes on 2026/07/29 @ 18:00 UTC -->
+
 </ResourceDictionary>

--- a/WUView/Languages/Strings.es-ES.xaml
+++ b/WUView/Languages/Strings.es-ES.xaml
@@ -15,7 +15,7 @@
 
         Translation contributed by:  My AWESOME brother Steve
 
-        Date last update:            2026/07/08
+        Date last update:            2026/07/29
 
         =======================================================================
 
@@ -50,7 +50,7 @@
     <sys:String x:Key="Button_Cancel">Cancelar</sys:String>
     <sys:String x:Key="Button_CheckUpdate">Comprobar actualización</sys:String>
     <sys:String x:Key="Button_Close">Cerrar este menú</sys:String>
-    <sys:String x:Key="Button_CompareLanguageToolTip">Haga clic para comparar el lenguaje actual con el predeterminado (EN-US). Los resultados se escriben en el archivo de registro.</sys:String>
+    <sys:String x:Key="Button_CompareLanguageToolTip" xml:space="preserve">Haga clic para comparar el lenguaje actual con el predeterminado (EN-US).&#x0a;Los resultados se escriben en el archivo de registro.</sys:String>
     <sys:String x:Key="Button_ExportSettings">Configuración de exportación</sys:String>
     <sys:String x:Key="Button_ExportSettingsToolTip">Exportar la configuración actual a un archivo.</sys:String>
     <sys:String x:Key="Button_ImportSettings">Configuración de importación</sys:String>
@@ -111,7 +111,7 @@
     <sys:String x:Key="MsgText_AllUpdatesExcluded">Se han excluido todas las actualizaciones visualizables.</sys:String>
     <sys:String x:Key="MsgText_ApplicationShutdown">apagando</sys:String>
     <sys:String x:Key="MsgText_ApplicationStarting">iniciando</sys:String>
-    <sys:String x:Key="MsgText_AppUpdateCheckFailed">Error en comprobar las actualizaciones. Consulte el registro para obtener más información.</sys:String>
+    <sys:String x:Key="MsgText_AppUpdateCheckFailed" xml:space="preserve">Error en comprobar las actualizaciones.&#x0a;Consulte el registro para obtener más información.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateChecking">Comprobación de actualizaciones.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateClose">Al hacer clic en "Sí" se cerrará el Visor Windows Update.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateGoToRelease">¿Ir a la página de lanzamiento?</sys:String>
@@ -204,7 +204,7 @@
     <sys:String x:Key="SettingsItem_StartCentered">Empezar con la ventana centrada en la pantalla</sys:String>
     <sys:String x:Key="SettingsItem_Theme">Tema</sys:String>
     <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Representa el número de cadenas en el idioma actual en comparación con el valor predeterminado (en-US).</sys:String>
-    <sys:String x:Key="SettingsItem_TranslationToolTipLine2">Presione Ctrl+Shift+K para comparar archivos de idioma. Los resultados se escriben en el archivo de registro.</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine2" xml:space="preserve">Presione Ctrl+Shift+K para comparar archivos de idioma.&#x0a;Los resultados se escriben en el archivo de registro.</sys:String>
     <sys:String x:Key="SettingsItem_UISize">Tamaño de la IU</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageCheckBox">Utilizar el idioma de visualización de Windows</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageToolTipLine1">Cuando se selecciona esta opción, se utilizará el idioma especificado en la configuración de Windows.</sys:String>

--- a/WUView/Languages/Strings.pl-PL.xaml
+++ b/WUView/Languages/Strings.pl-PL.xaml
@@ -1,4 +1,4 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:sys="clr-namespace:System;assembly=mscorlib">
 
@@ -13,12 +13,11 @@
 
         Language name:               Polski (pl-PL)
 
-        Translation contributed by:  FadeMind
+        Translation contributed by:  FadeMind & Google Translate
 
-        Date last update:            2024/04/05
+        Date last update:            2026/07/29
 
         ========================================================================
-
     -->
 
     <!--  About Page  -->
@@ -40,18 +39,31 @@
     <sys:String x:Key="About_LicenseText">Ten projekt jest licencjonowany na warunkach licencji MIT.</sys:String>
     <sys:String x:Key="About_LicenseToolTip">Zobacz licencję</sys:String>
     <sys:String x:Key="About_Translations">Tłumaczenia</sys:String>
+    <sys:String x:Key="About_UpdateFound">Dostępne jest nowsze wydanie</sys:String>
+    <sys:String x:Key="About_UpdateFoundTooltip">Kliknij, aby przejść do strony wydania w serwisie GitHub</sys:String>
     <sys:String x:Key="About_UpdateWU">Sprawdź dostępność aktualizacji WUView</sys:String>
     <sys:String x:Key="About_UpdateWUText">Sprawdź dostępność aktualizacji Windows Update Viewer</sys:String>
     <sys:String x:Key="About_UpdateWUToolTip">Sprawdź GitHub w poszukiwaniu nowszej wersji</sys:String>
     <sys:String x:Key="About_Version">Wersja</sys:String>
     <!--  Button Text  -->
     <sys:String x:Key="Button_Cancel">Anuluj</sys:String>
+    <sys:String x:Key="Button_CheckUpdate">Sprawdź dostępność aktualizacji</sys:String>
     <sys:String x:Key="Button_Close">Zamknij Menu</sys:String>
+    <sys:String x:Key="Button_CompareLanguageToolTip" xml:space="preserve">Kliknij, aby porównać bieżący język z domyślnym (en-US).&#x0a;Wyniki są zapisywane w pliku dziennika.</sys:String>
+    <sys:String x:Key="Button_ExportSettings">Eksportuj ustawienia</sys:String>
+    <sys:String x:Key="Button_ExportSettingsToolTip">Eksportuj bieżące ustawienia do pliku.</sys:String>
+    <sys:String x:Key="Button_ImportSettings">Importuj ustawienia</sys:String>
+    <sys:String x:Key="Button_ImportSettingsToolTip">Importuj ustawienia z pliku.</sys:String>
+    <sys:String x:Key="Button_ListSettings">Wyświetl ustawienia</sys:String>
+    <sys:String x:Key="Button_ListSettingsTooltip">Wyświetl (zapisz) ustawienia w pliku dziennika.</sys:String>
     <sys:String x:Key="Button_No">Nie</sys:String>
     <sys:String x:Key="Button_OK">OK</sys:String>
     <sys:String x:Key="Button_OpenAppFolder">Otwórz folder aplikacji</sys:String>
+    <sys:String x:Key="Button_OpenAppFolderToolTip">Otwórz folder tej aplikacji w Eksploratorze plików.</sys:String>
     <sys:String x:Key="Button_OpenLogFile">Przeglądaj dziennik</sys:String>
     <sys:String x:Key="Button_OpenLogFileToolTip">Otwórz plik dziennika w domyślnej aplikacji</sys:String>
+    <sys:String x:Key="Button_OpenSettings">Otwórz ustawienia</sys:String>
+    <sys:String x:Key="Button_OpenSettingsToolTip">Otwórz plik ustawień.</sys:String>
     <sys:String x:Key="Button_ThreeDotToolTip">Dodatkowe działania</sys:String>
     <sys:String x:Key="Button_Yes">Tak</sys:String>
     <!--  Details Pane  -->
@@ -98,7 +110,7 @@
     <sys:String x:Key="MsgText_AllUpdatesExcluded">Wszystkie widoczne aktualizacje zostały wykluczone.</sys:String>
     <sys:String x:Key="MsgText_ApplicationShutdown">jest zamykany</sys:String>
     <sys:String x:Key="MsgText_ApplicationStarting">uruchamia się</sys:String>
-    <sys:String x:Key="MsgText_AppUpdateCheckFailed">Sprawdzanie aktualizacji nie powiodło się. Więcej informacji można znaleźć w dzienniku.</sys:String>
+    <sys:String x:Key="MsgText_AppUpdateCheckFailed" xml:space="preserve">Sprawdzanie aktualizacji nie powiodło się.&#x0a;Więcej informacji można znaleźć w dzienniku.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateChecking">Sprawdzanie dostępności aktualizacji.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateClose">Kliknij 'TAK' aby zamknąć Windows Update Viewer.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateGoToRelease">Czy chcesz przejść do strony informacyjnej o wydaniu?</sys:String>
@@ -112,14 +124,20 @@
     <sys:String x:Key="MsgText_ElapsedTime">Upływ czasu</sys:String>
     <sys:String x:Key="MsgText_Error_TestLanguage">Wystąpił błąd w pliku tłumaczenia.</sys:String>
     <sys:String x:Key="MsgText_ErrorCaption">BŁĄD</sys:String>
+    <sys:String x:Key="MsgText_ErrorExportingSettings">Błąd eksportowania pliku ustawień.</sys:String>
+    <sys:String x:Key="MsgText_ErrorGeneral">Wystąpił błąd.</sys:String>
+    <sys:String x:Key="MsgText_ErrorImportingSettings">Błąd importowania pliku ustawień.</sys:String>
     <sys:String x:Key="MsgText_ErrorOpeningFile">Błąd otwierania {0}</sys:String>
     <sys:String x:Key="MsgText_ErrorReadingFile">Błąd odczytu {0}</sys:String>
+    <sys:String x:Key="MsgText_ErrorSeeLog">Więcej informacji znajduje się w pliku dziennika.</sys:String>
+    <sys:String x:Key="MsgText_ErrorSavingSettings">Błąd zapisywania pliku ustawień.</sys:String>
     <sys:String x:Key="MsgText_EventLogNA">Nie znaleziono zapisów dziennika zdarzeń dla tej aktualizacji.</sys:String>
     <sys:String x:Key="MsgText_EventLogNoRecords">Nie znaleziono rekordów Dziennika zdarzeń zawierających "{0}".</sys:String>
     <sys:String x:Key="MsgText_ExcludingContaining">Z wyłączeniem aktualizacji zawierających:</sys:String>
     <sys:String x:Key="MsgText_FilterOneRowShown">1 pokazany wiersz</sys:String>
     <sys:String x:Key="MsgText_FilterRowsShown">{0} pokazanych wierszy</sys:String>
     <sys:String x:Key="MsgText_HResultCopiedToClipboard">HResult {0} skopiowano do schowka</sys:String>
+    <sys:String x:Key="MsgText_ImportSettingsRestart">Uruchom ponownie Windows Update Viewer, aby użyć zaimportowanych ustawień.</sys:String>
     <sys:String x:Key="MsgText_ListRefreshed">Lista odświeżona</sys:String>
     <sys:String x:Key="MsgText_NoUpdatesFound">Nie znaleziono żadnych aktualizacji!</sys:String>
     <sys:String x:Key="MsgText_Opening">Otwieranie</sys:String>
@@ -151,16 +169,22 @@
     <!--  Settings Page Expander Headings  -->
     <sys:String x:Key="SettingsSection_AppSettings">Ustawienia</sys:String>
     <sys:String x:Key="SettingsSection_Language">Język</sys:String>
+    <sys:String x:Key="SettingsSection_SettingsFile">Plik ustawień</sys:String>
     <sys:String x:Key="SettingsSection_UISettings">Interfejs</sys:String>
     <sys:String x:Key="SettingsSubHead_AppSettings">Liczba aktualizacji, format daty, wykluczone elementy, szczegóły i inne.</sys:String>
     <sys:String x:Key="SettingsSubHead_Language">Language Settings and Testing</sys:String>
+    <sys:String x:Key="SettingsSubHead_SettingsFile">Importowanie, eksportowanie, otwieranie i wyświetlanie ustawień aplikacji</sys:String>
     <sys:String x:Key="SettingsSubHead_UISettings">Motyw, kolor akcentu, rozmiar interfejsu użytkownika, wysokość wiersza, pozycja początkowa i wiele więcej</sys:String>
     <!--  Settings Page Items  -->
     <sys:String x:Key="SettingsItem_AccentColor">Kolor akcentu</sys:String>
+    <sys:String x:Key="SettingsItem_AutoUpdateCheck">Automatycznie sprawdzaj nowszą wersję po otwarciu strony Informacje</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Po zmianie języka wymagany jest restart aplikacji!</sys:String>
+    <sys:String x:Key="SettingsItem_DisplayFont">Czcionka</sys:String>
+    <sys:String x:Key="SettingsItem_DisplayFontSize">Rozmiar czcionki</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Format daty siatki</sys:String>
-    <sys:String x:Key="SettingsItem_EnableLanguageTesting">Włącz testowanie języka</sys:String>
     <sys:String x:Key="SettingsItem_EditExcludeToolTip">Shift-Click aby otworzyć plik za pomocą domyślnej aplikacji</sys:String>
+    <sys:String x:Key="SettingsItem_EditSettingsWarning">Wszelkie zmiany wprowadzone w pliku ustawień podczas działania aplikacji zostaną nadpisane!</sys:String>
+    <sys:String x:Key="SettingsItem_EnableLanguageTesting">Włącz testowanie języka</sys:String>
     <sys:String x:Key="SettingsItem_HideExcluded">Ukryj wykluczone elementy</sys:String>
     <sys:String x:Key="SettingsItem_IncludeDebug">Uwzględnij komunikaty poziomu debugowania w pliku dziennika</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Okno Windows Update Viewer zawsze na wierzchu</sys:String>
@@ -175,8 +199,11 @@
     <sys:String x:Key="SettingsItem_ShowExit">Pokaż wyjście na pasku nawigacji</sys:String>
     <sys:String x:Key="SettingsItem_ShowLogWarnings">Wyświetlaj komunikaty ostrzegawcze w dzienniku dla niezerowych wartości HResult</sys:String>
     <sys:String x:Key="SettingsItem_ShowTodayInBold">Wyświetlaj aktualizacje z bieżącą datą pogrubioną czcionką</sys:String>
+    <sys:String x:Key="SettingsItem_SnackbarAccentColor">Użyj koloru akcentu dla tła komunikatu</sys:String>
     <sys:String x:Key="SettingsItem_StartCentered">Uruchamiaj z oknem wyśrodkowanym na ekranie</sys:String>
     <sys:String x:Key="SettingsItem_Theme">Motyw</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Przedstawia liczbę ciągów w bieżącym języku w porównaniu z domyślnym (en-US).</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine2" xml:space="preserve">Naciśnij Ctrl+Shift+K, aby porównać pliki językowe.&#x0a;Wyniki są zapisywane w pliku dziennika.</sys:String>
     <sys:String x:Key="SettingsItem_UISize">Skala</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageCheckBox">Użyj ustawień regionalnych systemu</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageToolTipLine1">Po wybraniu tej opcji zostanie użyty język określony w ustawieniach systemu Windows</sys:String>
@@ -219,6 +246,7 @@
     <sys:String x:Key="SettingsEnum_Spacing_Compact">Kompaktowy</sys:String>
     <sys:String x:Key="SettingsEnum_Spacing_Wide">Szeroki</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Dark">Material Dark</sys:String>
+    <sys:String x:Key="SettingsEnum_Theme_DarkBlue">Granatowy</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Darker">Darker</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Light">Light</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_System">System</sys:String>

--- a/WUView/Languages/Strings.sk-SK.xaml
+++ b/WUView/Languages/Strings.sk-SK.xaml
@@ -12,9 +12,9 @@
 
         Language name:               Slovak (sk-SK)
 
-        Translation contributed by:  VAIO
+        Translation contributed by:  VAIO & Google Translate
 
-        Date:                        02.11.2023
+        Date:                        2026/07/29
 
         ==================================================================================================================================
     -->
@@ -32,22 +32,37 @@
     <sys:String x:Key="About_Documentation">Dokumentácia</sys:String>
     <sys:String x:Key="About_DocumentationText">Otvorte súbor ReadMe</sys:String>
     <sys:String x:Key="About_DocumentationToolTip">Zobraziť súbor ReadMe</sys:String>
+    <sys:String x:Key="About_GitHub">GitHub</sys:String>
     <sys:String x:Key="About_GitHubToolTip">Navštívte stránku WUView na GitHub</sys:String>
     <sys:String x:Key="About_License">Licencia</sys:String>
     <sys:String x:Key="About_LicenseText">Tento projekt je licencovaný podľa podmienok licencie MIT.</sys:String>
     <sys:String x:Key="About_LicenseToolTip">Zobraziť licenčný dokument</sys:String>
     <sys:String x:Key="About_Translations">Preklady</sys:String>
+    <sys:String x:Key="About_UpdateFound">K dispozícii je novšie vydanie</sys:String>
+    <sys:String x:Key="About_UpdateFoundTooltip">Kliknutím prejdete na stránku vydania na GitHube</sys:String>
     <sys:String x:Key="About_UpdateWU">Aktualizovať WUView</sys:String>
     <sys:String x:Key="About_UpdateWUText">Vyhľadajte nové vydanie programu Windows Update Viewer</sys:String>
     <sys:String x:Key="About_UpdateWUToolTip">Vyhľadajte na GitHub novšie vydanie</sys:String>
     <sys:String x:Key="About_Version">Verzia</sys:String>
     <!--  Button Text  -->
     <sys:String x:Key="Button_Cancel">Zrušiť</sys:String>
+    <sys:String x:Key="Button_CheckUpdate">Skontrolovať aktualizáciu</sys:String>
+    <sys:String x:Key="Button_Close">Zavrieť menu</sys:String>
+    <sys:String x:Key="Button_CompareLanguageToolTip" xml:space="preserve">Kliknutím porovnáte aktuálny jazyk s predvoleným (en-US).&#x0a;Výsledky sa zapíšu do súboru denníka.</sys:String>
+    <sys:String x:Key="Button_ExportSettings">Exportovať nastavenia</sys:String>
+    <sys:String x:Key="Button_ExportSettingsToolTip">Exportovať aktuálne nastavenia do súboru.</sys:String>
+    <sys:String x:Key="Button_ImportSettings">Importovať nastavenia</sys:String>
+    <sys:String x:Key="Button_ImportSettingsToolTip">Importovať nastavenia zo súboru.</sys:String>
+    <sys:String x:Key="Button_ListSettings">Zoznam nastavení</sys:String>
+    <sys:String x:Key="Button_ListSettingsTooltip">Vypísať (zapísať) nastavenia do súboru denníka.</sys:String>
     <sys:String x:Key="Button_No">Nie</sys:String>
     <sys:String x:Key="Button_OK">OK</sys:String>
     <sys:String x:Key="Button_OpenAppFolder">Otvoriť priečinok aplikácie</sys:String>
+    <sys:String x:Key="Button_OpenAppFolderToolTip">Otvorte priečinok tejto aplikácie v Prieskumníkovi súborov.</sys:String>
     <sys:String x:Key="Button_OpenLogFile">Zobraziť súbor denníka</sys:String>
     <sys:String x:Key="Button_OpenLogFileToolTip">Otvorte súbor denníka v predvolenej aplikácii.</sys:String>
+    <sys:String x:Key="Button_OpenSettings">Otvoriť nastavenia</sys:String>
+    <sys:String x:Key="Button_OpenSettingsToolTip">Otvorte súbor nastavení.</sys:String>
     <sys:String x:Key="Button_ThreeDotToolTip">Ďalšie akcie</sys:String>
     <sys:String x:Key="Button_Yes">Áno</sys:String>
     <!--  Details Pane  -->
@@ -97,8 +112,9 @@
     <sys:String x:Key="MsgText_AllUpdatesExcluded">Všetky zobrazené aktualizácie boli vylúčené.</sys:String>
     <sys:String x:Key="MsgText_ApplicationShutdown">vypína sa</sys:String>
     <sys:String x:Key="MsgText_ApplicationStarting">spúšťa sa</sys:String>
-    <sys:String x:Key="MsgText_AppUpdateCheckFailed">Kontrola aktualizácie zlyhala. Viac informácií nájdete v denníku.</sys:String>
+    <sys:String x:Key="MsgText_AppUpdateCheckFailed" xml:space="preserve">Kontrola aktualizácie zlyhala.&#x0a;Viac informácií nájdete v denníku.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateChecking">Kontroluje sa aktualizácia.</sys:String>
+    <sys:String x:Key="MsgText_AppUpdateClose">Kliknutím na „Áno“ sa zavrie Windows Update Viewer.</sys:String>
     <sys:String x:Key="MsgText_AppUpdateGoToRelease">Chcete prejsť na stránku vydania?</sys:String>
     <sys:String x:Key="MsgText_AppUpdateNewerFound">Našlo sa novšie vydanie ({0}).</sys:String>
     <sys:String x:Key="MsgText_AppUpdateNoneFound">Nenašli sa žiadne novšie vydania.</sys:String>
@@ -109,12 +125,21 @@
     <sys:String x:Key="MsgText_DisplayedUpdates">Zobrazuje sa {0} z {1} aktualizácií</sys:String>
     <sys:String x:Key="MsgText_ElapsedTime">Uplynulý čas</sys:String>
     <sys:String x:Key="MsgText_Error_TestLanguage">Vyskytol sa problém s jazykovým súborom.</sys:String>
+    <sys:String x:Key="MsgText_ErrorCaption">CHYBA</sys:String>
+    <sys:String x:Key="MsgText_ErrorExportingSettings">Chyba pri exporte súboru nastavení.</sys:String>
+    <sys:String x:Key="MsgText_ErrorGeneral">Vyskytla sa chyba.</sys:String>
+    <sys:String x:Key="MsgText_ErrorImportingSettings">Chyba pri importe súboru nastavení.</sys:String>
+    <sys:String x:Key="MsgText_ErrorOpeningFile">Chyba pri otváraní súboru {0}</sys:String>
+    <sys:String x:Key="MsgText_ErrorReadingFile">Chyba pri čítaní súboru {0}</sys:String>
+    <sys:String x:Key="MsgText_ErrorSeeLog">Viac informácií nájdete v súbore denníka.</sys:String>
+    <sys:String x:Key="MsgText_ErrorSavingSettings">Chyba pri ukladaní súboru nastavení.</sys:String>
     <sys:String x:Key="MsgText_EventLogNA">Pre túto aktualizáciu sa nenašli žiadne záznamy denníkov udalostí.</sys:String>
     <sys:String x:Key="MsgText_EventLogNoRecords">Nenašli sa žiadne záznamy denníka udalostí obsahujúce „{0}“.</sys:String>
     <sys:String x:Key="MsgText_ExcludingContaining">S výnimkou aktualizácií obsahujúcich:</sys:String>
     <sys:String x:Key="MsgText_FilterOneRowShown">Zobrazuje sa 1 riadok</sys:String>
     <sys:String x:Key="MsgText_FilterRowsShown">Zobrazené riadky: {0}</sys:String>
     <sys:String x:Key="MsgText_HResultCopiedToClipboard">Výsledok HR {0} bol skopírovaný do schránky</sys:String>
+    <sys:String x:Key="MsgText_ImportSettingsRestart">Aby ste mohli použiť importované nastavenia, reštartujte Windows Update Viewer.</sys:String>
     <sys:String x:Key="MsgText_ListRefreshed">Obnovený zoznam</sys:String>
     <sys:String x:Key="MsgText_NoUpdatesFound">Nenašli sa žiadne aktualizácie!</sys:String>
     <sys:String x:Key="MsgText_Opening">Otváranie</sys:String>
@@ -143,15 +168,21 @@
     <!--  Settings Page Expander Headings  -->
     <sys:String x:Key="SettingsSection_AppSettings">Nastavenia aplikácie</sys:String>
     <sys:String x:Key="SettingsSection_Language">Jazyk</sys:String>
+    <sys:String x:Key="SettingsSection_SettingsFile">Súbor nastavení</sys:String>
     <sys:String x:Key="SettingsSection_UISettings">Nastavenia používateľského rozhrania</sys:String>
     <sys:String x:Key="SettingsSubHead_AppSettings">Počet aktualizácií, formát dátumu, vylúčené položky, podrobnosti a ďalšie</sys:String>
     <sys:String x:Key="SettingsSubHead_Language">Nastavenia jazyka (prebieha spracovanie)</sys:String>
+    <sys:String x:Key="SettingsSubHead_SettingsFile">Importovať, exportovať, otvoriť a vypísať nastavenia aplikácie</sys:String>
     <sys:String x:Key="SettingsSubHead_UISettings">Motív, farba zvýraznenia, veľkosť používateľského rozhrania, výška riadku, počiatočná pozícia a ďalšie</sys:String>
     <!--  Settings Page Items  -->
     <sys:String x:Key="SettingsItem_AccentColor">Farba zvýraznenia</sys:String>
+    <sys:String x:Key="SettingsItem_AutoUpdateCheck">Automaticky kontrolovať novšiu verziu pri otvorení stránky O programe</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Zmena jazyka spôsobí reštart aplikácie!</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Formát dátumu mriežky</sys:String>
+    <sys:String x:Key="SettingsItem_DisplayFont">Písmo</sys:String>
+    <sys:String x:Key="SettingsItem_DisplayFontSize">Veľkosť písma</sys:String>
     <sys:String x:Key="SettingsItem_EditExcludeToolTip">Ak chcete otvoriť súbor s predvolenou aplikáciou, kliknite so stlačeným klávesom Shift</sys:String>
+    <sys:String x:Key="SettingsItem_EditSettingsWarning">Všetky zmeny vykonané v súbore nastavení počas behu aplikácie budú prepísané!</sys:String>
     <sys:String x:Key="SettingsItem_EnableLanguageTesting">Povoliť testovanie jazyka</sys:String>
     <sys:String x:Key="SettingsItem_HideExcluded">Skryť vylúčené položky</sys:String>
     <sys:String x:Key="SettingsItem_IncludeDebug">Zahrnúť správy na úrovni ladenia do súboru denníka</sys:String>
@@ -167,8 +198,11 @@
     <sys:String x:Key="SettingsItem_ShowExit">Zobraziť ukončenie na navigačnom paneli</sys:String>
     <sys:String x:Key="SettingsItem_ShowLogWarnings">Zobraziť v denníku varovné správy pre nenulové hodnoty HResult</sys:String>
     <sys:String x:Key="SettingsItem_ShowTodayInBold">Zobraziť aktualizácie s aktuálnym dátumom tučným písmom</sys:String>
+    <sys:String x:Key="SettingsItem_SnackbarAccentColor">Použiť farbu zvýraznenia pre pozadie správy</sys:String>
     <sys:String x:Key="SettingsItem_StartCentered">Začnite s oknom vycentrovaným na obrazovke</sys:String>
     <sys:String x:Key="SettingsItem_Theme">Motív</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Predstavuje počet reťazcov v aktuálnom jazyku v porovnaní s predvoleným (en-US).</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine2" xml:space="preserve">Stlačením Ctrl+Shift+K porovnáte jazykové súbory.&#x0a;Výsledky sa zapíšu do súboru denníka.</sys:String>
     <sys:String x:Key="SettingsItem_UISize">Veľkosť používateľského rozhrania</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageCheckBox">Použiť jazyk zobrazenia systému Windows</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageToolTipLine1">Ak je vybratá táto možnosť, jazyk zadaný v nastaveniach systému Windows bude</sys:String>
@@ -213,31 +247,10 @@
     <sys:String x:Key="SettingsEnum_Spacing_Compact">Kompaktné</sys:String>
     <sys:String x:Key="SettingsEnum_Spacing_Wide">Široký</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Dark">Tmavý materiál</sys:String>
+    <sys:String x:Key="SettingsEnum_Theme_DarkBlue">Polnočná modrá</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Darker">Tmavšie</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_Light">Svetlo</sys:String>
     <sys:String x:Key="SettingsEnum_Theme_System">Systém</sys:String>
 
-    <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    LANGUAGE FILE UPDATES
-
-    Additions, Deletions and Updates will be made in the appropriate sections above. Each change will
-    be associated with a comment made below this block.
-
-    Comment Format:
-       There will be a header indicating when the change was made (date yyyy/mm/dd and UTC time).
-       Modified lines will follow, one comment line per line changed.
-       Comment lines use this syntax:  Change Type | Key Name
-
-     Change type:
-       A = Added
-       D = Deleted
-       U = Updated
-       * = Comment not related to a single line
-     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -->
-
-    <!-- Begin changes on 2023/11/14 @ 01:15 UTC -->
-    <!-- U | Value for About_Contribute needs to be updated to "Contribute a Translation" -->
-    <!-- A | About_GitHub needs to be added -->
-    <!-- A | Button_Close needs to be added -->
-    <!-- End of changes on 2023/11/14 -->
 </ResourceDictionary>
+<!-- See Strings.en-US for change history -->

--- a/WUView/Models/UILanguage.cs
+++ b/WUView/Models/UILanguage.cs
@@ -80,7 +80,7 @@ public partial class UILanguage : ObservableObject
         new () {Language = "Dutch",               LanguageCode = "nl-NL", LanguageNative = "Nederlands",         Contributor = "CMTriX"},
         new () {Language = "German",              LanguageCode = "de-DE", LanguageNative = "Deutsch",            Contributor = "Timthreetwelve & Henry2o1o"},
         new () {Language = "French",              LanguageCode = "fr-FR", LanguageNative = "Français",           Contributor = "Timthreetwelve"},
-        //new () {Language = "Catalan",             LanguageCode = "ca-ES", LanguageNative = "Català",             Contributor = "Timthreetwelve"},
+        new () {Language = "Catalan",             LanguageCode = "ca-ES", LanguageNative = "Català",             Contributor = "Timthreetwelve"},
         new () {Language = "Polish",              LanguageCode = "pl-PL", LanguageNative = "Polski",             Contributor = "FadeMind"},
         new () {Language = "Slovak",              LanguageCode = "sk-SK", LanguageNative = "Slovenčina",         Contributor = "VAIO"},
         new () {Language = "Slovenian",           LanguageCode = "sl-SL", LanguageNative = "Slovenščina",        Contributor = "Jadran Rudec & Marko K.(MaXi)"},


### PR DESCRIPTION
Update language files

- Updated Catalan, Spanish, Polish, and Slovak resource files with help from Copilot.
- Added xml:space="preserve" and line breaks for better formatting.
- Updated en-US file and change log.
- Re-enabled Catalan in UILanguage.cs.