### PR TITLE
Support separate light/dark themes for System mode

### DIFF
--- a/WUView/App.xaml
+++ b/WUView/App.xaml
@@ -18,6 +18,7 @@
                 <ResourceDictionary Source="Languages/Strings.en-US.xaml" />
                 <!--  Styles  -->
                 <ResourceDictionary Source="Styles/ButtonStyles.xaml" />
+                <ResourceDictionary Source="Styles/ComboBoxStyle.xaml" />
                 <ResourceDictionary Source="Styles/DataGridStyles.xaml" />
                 <ResourceDictionary Source="Styles/ExpanderStyles.xaml" />
                 <ResourceDictionary Source="Styles/HyperlinkStyles.xaml" />

--- a/WUView/Configuration/SettingChange.cs
+++ b/WUView/Configuration/SettingChange.cs
@@ -44,6 +44,11 @@ public static class SettingChange
             case nameof(UserSettings.Setting.UseOSLanguage):
                 LocalizationHelpers.SaveAndRestart();
                 break;
+
+            case nameof(UserSettings.Setting.SystemLightTheme):
+            case nameof(UserSettings.Setting.SystemDarkTheme):
+                MainWindowHelpers.SetBaseTheme(ThemeType.System);
+                break;
         }
     }
     #endregion User Setting change

--- a/WUView/Configuration/UserSettings.cs
+++ b/WUView/Configuration/UserSettings.cs
@@ -152,6 +152,18 @@ internal sealed partial class UserSettings : ConfigManager<UserSettings>
     private bool _startCentered = true;
 
     /// <summary>
+    /// Theme to use for light mode when ThemeType.System is selected.
+    /// </summary>
+    [ObservableProperty]
+    private ThemeType _systemLightTheme = ThemeType.Light;
+
+    /// <summary>
+    /// Theme to use for dark mode when ThemeType.System is selected.
+    /// </summary>
+    [ObservableProperty]
+    private ThemeType _systemDarkTheme = ThemeType.Darker;
+
+    /// <summary>
     /// Defined language to use in the UI.
     /// </summary>
     [ObservableProperty]

--- a/WUView/Converters/EnumToVisibilityConverter.cs
+++ b/WUView/Converters/EnumToVisibilityConverter.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Tim Kennedy. All Rights Reserved. Licensed under the MIT License.
+
+namespace WUView.Converters;
+
+/// <summary>
+/// Converts an enum value to Visibility based on whether it matches the parameter.
+/// Returns Visible if the value equals the parameter, otherwise Collapsed.
+/// </summary>
+public class EnumToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value == null || parameter == null)
+        {
+            return Visibility.Collapsed;
+        }
+
+        return value.Equals(parameter) ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return Binding.DoNothing;
+    }
+}

--- a/WUView/Helpers/MainWindowHelpers.cs
+++ b/WUView/Helpers/MainWindowHelpers.cs
@@ -146,16 +146,16 @@ internal static class MainWindowHelpers
     /// Gets the current MDIX theme
     /// </summary>
     /// <returns>Dark or Light</returns>
-    private static string? GetSystemTheme()
+    private static string GetSystemTheme()
     {
         BaseTheme? sysTheme = Theme.GetSystemTheme();
-        return sysTheme != null ? sysTheme.ToString() : string.Empty;
+        return sysTheme != null ? sysTheme.ToString()! : string.Empty;
     }
 
     /// <summary>
     /// Sets the theme
     /// </summary>
-    /// <param name="mode">Light, Dark, Darker or System</param>
+    /// <param name="mode">A value in the ThemeType enum </param>
     internal static void SetBaseTheme(ThemeType mode)
     {
         //Retrieve the app's existing theme
@@ -164,7 +164,18 @@ internal static class MainWindowHelpers
 
         if (mode == ThemeType.System)
         {
-            mode = GetSystemTheme()!.Equals("light", StringComparison.OrdinalIgnoreCase) ? ThemeType.Light : ThemeType.Darker;
+            string systemTheme = GetSystemTheme();
+            mode = systemTheme.Equals("light", StringComparison.OrdinalIgnoreCase)
+                ? UserSettings.Setting!.SystemLightTheme
+                : UserSettings.Setting!.SystemDarkTheme;
+
+            // Guard against invalid config values (e.g., System) so we always apply a concrete theme.
+            if (mode == ThemeType.System)
+            {
+                mode = systemTheme.Equals("light", StringComparison.OrdinalIgnoreCase)
+                    ? ThemeType.Light
+                    : ThemeType.Darker;
+            }
         }
 
         switch (mode)

--- a/WUView/Languages/Strings.ca-ES.xaml
+++ b/WUView/Languages/Strings.ca-ES.xaml
@@ -179,6 +179,7 @@
     <sys:String x:Key="SettingsItem_AccentColor">Color d'accent</sys:String>
     <sys:String x:Key="SettingsItem_AutoUpdateCheck">Comprova automàticament si hi ha una versió més recent quan s'obre la pàgina Sobre</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Si canvieu d'idioma, l'aplicació es reiniciarà!</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Tema del mode fosc</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Format de data de quadrícula</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Tipus de lletra</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFontSize">Mida de la lletra</sys:String>
@@ -189,6 +190,7 @@
     <sys:String x:Key="SettingsItem_IncludeDebug">Inclou missatges de nivell de depuració al fitxer de registre</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Manteniu Windows Update Viewer a sobre d'altres finestres</sys:String>
     <sys:String x:Key="SettingsItem_Language">Llenguatge</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Tema del mode clar</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdates">Nombre d'actualitzacions</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine1">Aquest és el nombre màxim d'actualitzacions que cal processar abans que s'excloguin cap actualització.</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine2">Establir-lo a un valor més baix pot millorar el rendiment.</sys:String>

--- a/WUView/Languages/Strings.en-US.xaml
+++ b/WUView/Languages/Strings.en-US.xaml
@@ -179,6 +179,7 @@
     <sys:String x:Key="SettingsItem_AccentColor">Accent Color</sys:String>
     <sys:String x:Key="SettingsItem_AutoUpdateCheck">Automatically check for newer version when About page is opened</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Changing Language will cause application to restart!</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Dark Mode Theme</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Font</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFontSize">Font Size</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Grid Date Format</sys:String>
@@ -189,6 +190,7 @@
     <sys:String x:Key="SettingsItem_IncludeDebug">Include debug level messages in log file</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Keep Windows Update Viewer on top of other windows</sys:String>
     <sys:String x:Key="SettingsItem_Language">Language</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Light Mode Theme</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdates">Number of Updates</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine1">This is the maximum number of updates to process before any updates are excluded.</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine2">Setting this to a lower value may improve performance.</sys:String>
@@ -372,6 +374,8 @@
 
     <!-- Begin changes on 2026/07/29 @ 21:00 UTC-->
     <!-- A | SettingsEnum_Theme_LightGray  -->
+    <!-- A | SettingsItem_LightModeTheme  -->
+    <!-- A | SettingsItem_DarkModeTheme  -->
     <!-- End of changes on 2026/07/29 @ 21:00 UTC-->
 
 </ResourceDictionary>

--- a/WUView/Languages/Strings.es-ES.xaml
+++ b/WUView/Languages/Strings.es-ES.xaml
@@ -15,10 +15,9 @@
 
         Translation contributed by:  My AWESOME brother Steve
 
-        Date last update:            2026/07/29
+        Date last update:            2026/07/30
 
         =======================================================================
-
     -->
 
     <!--  About Page  -->
@@ -180,6 +179,7 @@
     <sys:String x:Key="SettingsItem_AccentColor">Color de acento</sys:String>
     <sys:String x:Key="SettingsItem_AutoUpdateCheck">Buscar automáticamente una versión más nueva al abrir la página Acerca de</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">El cambio de idioma hará que la aplicación se reinicie</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Tema del modo oscuro</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Formato de fecha de cuadrícula</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Fuente</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFontSize">Tamaño de la fuente</sys:String>
@@ -190,6 +190,7 @@
     <sys:String x:Key="SettingsItem_IncludeDebug">Incluir mensajes de nivel de depuración en el archivo de registro</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Mantener Windows Update Viewer encima de otras ventanas</sys:String>
     <sys:String x:Key="SettingsItem_Language">Idioma:</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Tema del modo claro</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdates">Número de actualizaciones</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine1">Es el número máximo de actualizaciones a procesar antes de exclusiones.</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine2">Un valor inferior puede mejorar el rendimiento.</sys:String>

--- a/WUView/Languages/Strings.fr-FR.xaml
+++ b/WUView/Languages/Strings.fr-FR.xaml
@@ -15,10 +15,9 @@
 
         Translation contributed by:  @Timthreetwelve & Google Translate
 
-        Date LAST UPDATE:            2026/05/18
+        Date LAST UPDATE:            2026/07/30
 
         ========================================================================
-
     -->
 
     <!--  About Page  -->
@@ -180,6 +179,7 @@
     <sys:String x:Key="SettingsItem_AccentColor">Couleur d'accentuation</sys:String>
     <sys:String x:Key="SettingsItem_AutoUpdateCheck">Rechercher automatiquement une version plus récente à l'ouverture de la page À propos</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Changer la langue entraînera le redémarrage de l'application!</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Thème sombre</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Format de date de grille</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Fonte</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFontSize">Taille de la police</sys:String>
@@ -190,6 +190,7 @@
     <sys:String x:Key="SettingsItem_IncludeDebug">Inclure les messages de niveau de débogage dans le fichier journal</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Gardez la visionneuse Windows Update au-dessus des autres fenêtres</sys:String>
     <sys:String x:Key="SettingsItem_Language">Langue</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Thème clair</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdates">Nombre de mises à jour</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine1">Il s'agit du nombre maximum de mises à jour à traiter avant que les mises à jour ne soient exclues.</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine2">Définir cette valeur sur une valeur inférieure peut améliorer les performances.</sys:String>
@@ -200,15 +201,15 @@
     <sys:String x:Key="SettingsItem_ShowExit">Afficher la sortie dans la barre de navigation</sys:String>
     <sys:String x:Key="SettingsItem_ShowLogWarnings">Afficher les messages d'avertissement dans le journal pour les valeurs HResult non nulles</sys:String>
     <sys:String x:Key="SettingsItem_ShowTodayInBold">Afficher les mises à jour avec la date actuelle en gras</sys:String>
+    <sys:String x:Key="SettingsItem_SnackbarAccentColor">Utiliser la couleur d'accentuation pour l'arrière-plan du message</sys:String>
     <sys:String x:Key="SettingsItem_StartCentered">Commencez avec la fenêtre centrée sur l'écran</sys:String>
     <sys:String x:Key="SettingsItem_Theme">Thème</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Représente le nombre de chaînes dans la langue actuelle par rapport à la langue par défaut (en-US).</sys:String>
+    <sys:String x:Key="SettingsItem_TranslationToolTipLine2">Appuyez sur Ctrl+Maj+K ou cliquez sur le bouton Comparer pour comparer les fichiers de langue. Les résultats sont enregistrés dans le fichier journal.</sys:String>
     <sys:String x:Key="SettingsItem_UISize">Taille de l'interface utilisateur</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageCheckBox">Utiliser la langue d'affichage de Windows</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageToolTipLine1">Lorsque cette option est sélectionnée, la langue spécifiée dans les paramètres Windows sera utilisée.</sys:String>
     <sys:String x:Key="SettingsItem_UseOSLanguageToolTipLine2">La plupart du texte de la candidature restera en anglais (en-US), mais les formats de chiffres changeront.</sys:String>
-    <sys:String x:Key="SettingsItem_SnackbarAccentColor">Utiliser la couleur d'accentuation pour l'arrière-plan du message</sys:String>
-    <sys:String x:Key="SettingsItem_TranslationToolTipLine1">Représente le nombre de chaînes dans la langue actuelle par rapport à la langue par défaut (en-US).</sys:String>
-    <sys:String x:Key="SettingsItem_TranslationToolTipLine2">Appuyez sur Ctrl+Maj+K ou cliquez sur le bouton Comparer pour comparer les fichiers de langue. Les résultats sont enregistrés dans le fichier journal.</sys:String>
     <!--  Enums for Combo Boxes on the Settings Page  -->
     <sys:String x:Key="SettingsEnum_AccentColor_Amber">Ambre</sys:String>
     <sys:String x:Key="SettingsEnum_AccentColor_Black">Noir</sys:String>

--- a/WUView/Languages/Strings.pl-PL.xaml
+++ b/WUView/Languages/Strings.pl-PL.xaml
@@ -15,7 +15,7 @@
 
         Translation contributed by:  FadeMind & Google Translate
 
-        Date last update:            2026/07/29
+        Date last update:            2026/07/30
 
         ========================================================================
     -->
@@ -179,9 +179,10 @@
     <sys:String x:Key="SettingsItem_AccentColor">Kolor akcentu</sys:String>
     <sys:String x:Key="SettingsItem_AutoUpdateCheck">Automatycznie sprawdzaj nowszą wersję po otwarciu strony Informacje</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Po zmianie języka wymagany jest restart aplikacji!</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Motyw trybu ciemnego</sys:String>
+    <sys:String x:Key="SettingsItem_DateFormat">Format daty siatki</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Czcionka</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFontSize">Rozmiar czcionki</sys:String>
-    <sys:String x:Key="SettingsItem_DateFormat">Format daty siatki</sys:String>
     <sys:String x:Key="SettingsItem_EditExcludeToolTip">Shift-Click aby otworzyć plik za pomocą domyślnej aplikacji</sys:String>
     <sys:String x:Key="SettingsItem_EditSettingsWarning">Wszelkie zmiany wprowadzone w pliku ustawień podczas działania aplikacji zostaną nadpisane!</sys:String>
     <sys:String x:Key="SettingsItem_EnableLanguageTesting">Włącz testowanie języka</sys:String>
@@ -189,6 +190,7 @@
     <sys:String x:Key="SettingsItem_IncludeDebug">Uwzględnij komunikaty poziomu debugowania w pliku dziennika</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Okno Windows Update Viewer zawsze na wierzchu</sys:String>
     <sys:String x:Key="SettingsItem_Language">Język</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Motyw trybu jasnego</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdates">Ilość aktualizacji</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine1">Jest to maksymalna ilość aktualizacji do przetworzenia, zanim jakiekolwiek aktualizacje zostaną wykluczone.</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine2">Ustawienie niższej wartości może poprawić wydajność.</sys:String>

--- a/WUView/Languages/Strings.sk-SK.xaml
+++ b/WUView/Languages/Strings.sk-SK.xaml
@@ -14,7 +14,7 @@
 
         Translation contributed by:  VAIO & Google Translate
 
-        Date:                        2026/07/29
+        Date:                        2026/07/30
 
         ==================================================================================================================================
     -->
@@ -178,6 +178,7 @@
     <sys:String x:Key="SettingsItem_AccentColor">Farba zvýraznenia</sys:String>
     <sys:String x:Key="SettingsItem_AutoUpdateCheck">Automaticky kontrolovať novšiu verziu pri otvorení stránky O programe</sys:String>
     <sys:String x:Key="SettingsItem_ChangingLanguageWarning">Zmena jazyka spôsobí reštart aplikácie!</sys:String>
+    <sys:String x:Key="SettingsItem_DarkModeTheme">Motív tmavého režimu</sys:String>
     <sys:String x:Key="SettingsItem_DateFormat">Formát dátumu mriežky</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFont">Písmo</sys:String>
     <sys:String x:Key="SettingsItem_DisplayFontSize">Veľkosť písma</sys:String>
@@ -188,6 +189,7 @@
     <sys:String x:Key="SettingsItem_IncludeDebug">Zahrnúť správy na úrovni ladenia do súboru denníka</sys:String>
     <sys:String x:Key="SettingsItem_KeepOnTop">Uchovávajte Windows Update Viewer nad ostatnými oknami</sys:String>
     <sys:String x:Key="SettingsItem_Language">Jazyk</sys:String>
+    <sys:String x:Key="SettingsItem_LightModeTheme">Téma svetlého režimu</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdates">Počet aktualizácií</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine1">Toto je maximálny počet aktualizácií, ktoré sa majú spracovať pred vylúčením akýchkoľvek aktualizácií.</sys:String>
     <sys:String x:Key="SettingsItem_NumberOfUpdatesToolTipLine2">Nastavenie na nižšiu hodnotu môže zlepšiť výkon.</sys:String>

--- a/WUView/Styles/ComboBoxStyle.xaml
+++ b/WUView/Styles/ComboBoxStyle.xaml
@@ -1,0 +1,19 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <!--#region Style for ComboBoxes on Settings pages-->
+    <Style TargetType="ComboBox"
+           x:Key="SettingsComboBox"
+           BasedOn="{StaticResource MaterialDesignComboBox}">
+        <Setter Property="Padding" Value="3,0,0,3" />
+        <Setter Property="Height" Value="34" />
+        <Setter Property="Width" Value="Auto" />
+        <Setter Property="MinWidth" Value="200" />
+        <Setter Property="HorizontalAlignment" Value="Left" />
+        <Setter Property="VerticalAlignment" Value="Bottom" />
+        <Setter Property="Margin" Value="0,3,0,0" />
+    </Style>
+    <!--#endregion-->
+
+
+</ResourceDictionary>

--- a/WUView/ViewModels/SettingsViewModel.cs
+++ b/WUView/ViewModels/SettingsViewModel.cs
@@ -7,6 +7,8 @@ internal sealed partial class SettingsViewModel : ObservableObject
     #region Properties
     public static List<FontFamily>? FontList { get; private set; }
     public IEnumerable<ThemeType> ThemeTypes { get; private set; }
+
+    public IEnumerable<ThemeType> SystemThemeTypes { get; private set; }
     #endregion Properties
 
     #region Constructor
@@ -23,7 +25,12 @@ internal sealed partial class SettingsViewModel : ObservableObject
             ThemeType.DarkBlue,
             ThemeType.System,
         ];
+
+        // Used when ThemeType.System is selected. Will display all themes except System theme
+        SystemThemeTypes = [.. ThemeTypes.Where(t => t != ThemeType.System)];
+
     }
+
     #endregion Constructor
 
     #region Relay commands

--- a/WUView/Views/SettingsPage.xaml
+++ b/WUView/Views/SettingsPage.xaml
@@ -24,6 +24,7 @@
 
     <UserControl.Resources>
         <convert:BooleanInverter x:Key="BoolInverter" />
+        <convert:EnumToVisibilityConverter x:Key="EnumToVisibility" />
         <viewmodels:NavigationViewModel x:Key="NavVm" />
     </UserControl.Resources>
     <!--#endregion-->
@@ -272,78 +273,102 @@
                         <!--#region ComboBoxes (top)-->
                         <Grid Grid.Row="0" Grid.Column="1">
                             <Grid.RowDefinitions>
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
-                                <RowDefinition Height="38" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="auto" MinWidth="100" />
                                 <ColumnDefinition Width="10" />
                                 <ColumnDefinition />
                             </Grid.ColumnDefinitions>
+                            <Grid.DataContext>
+                                <viewmodels:SettingsViewModel />
+                            </Grid.DataContext>
 
                             <Label Grid.Row="0" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_Theme}" />
-                            <StackPanel Grid.Row="0" Grid.Column="2">
-                                <StackPanel.DataContext>
-                                    <viewmodels:SettingsViewModel />
-                                </StackPanel.DataContext>
-                                <ComboBox Width="Auto" MinWidth="200"
-                                          Margin="0,3,0,0" Padding="2,0,0,3"
-                                          HorizontalAlignment="Left"
-                                          ItemsSource="{Binding ThemeTypes}"
-                                          SelectedItem="{Binding Path=UITheme,
-                                                                 Source={x:Static config:UserSettings.Setting}}"
-                                          Style="{StaticResource MaterialDesignComboBox}" />
-                            </StackPanel>
+                            <ComboBox Grid.Row="0" Grid.Column="2"
+                                      ItemsSource="{Binding ThemeTypes}"
+                                      SelectedItem="{Binding Path=UITheme,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource SettingsComboBox}" />
 
                             <Label Grid.Row="1" Grid.Column="0"
                                    VerticalAlignment="Center"
-                                   Content="{DynamicResource SettingsItem_UISize}" />
+                                   Content="{DynamicResource SettingsItem_LightModeTheme}"
+                                   Visibility="{Binding UITheme,
+                                                        Source={x:Static config:UserSettings.Setting},
+                                                        Converter={StaticResource EnumToVisibility},
+                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
                             <ComboBox Grid.Row="1" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="2,0,0,3"
-                                      HorizontalAlignment="Left"
-                                      ItemsSource="{Binding Source={convert:EnumBindingSource {x:Type models:MySize}}}"
-                                      SelectedItem="{Binding UISize,
+                                      ItemsSource="{Binding SystemThemeTypes}"
+                                      SelectedItem="{Binding SystemLightTheme,
                                                              Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
+                                      Style="{StaticResource SettingsComboBox}"
+                                      Visibility="{Binding UITheme,
+                                                           Source={x:Static config:UserSettings.Setting},
+                                                           Converter={StaticResource EnumToVisibility},
+                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
 
                             <Label Grid.Row="2" Grid.Column="0"
                                    VerticalAlignment="Center"
-                                   Content="{DynamicResource SettingsItem_AccentColor}" />
+                                   Content="{DynamicResource SettingsItem_DarkModeTheme}"
+                                   Visibility="{Binding UITheme,
+                                                        Source={x:Static config:UserSettings.Setting},
+                                                        Converter={StaticResource EnumToVisibility},
+                                                        ConverterParameter={x:Static models:ThemeType.System}}" />
                             <ComboBox Grid.Row="2" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="2,0,0,3"
-                                      HorizontalAlignment="Left"
+                                      ItemsSource="{Binding SystemThemeTypes}"
+                                      SelectedItem="{Binding SystemDarkTheme,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource SettingsComboBox}"
+                                      Visibility="{Binding UITheme,
+                                                           Source={x:Static config:UserSettings.Setting},
+                                                           Converter={StaticResource EnumToVisibility},
+                                                           ConverterParameter={x:Static models:ThemeType.System}}" />
+
+                            <Label Grid.Row="3" Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Content="{DynamicResource SettingsItem_UISize}" />
+                            <ComboBox Grid.Row="3" Grid.Column="2"
+                                      ItemsSource="{Binding Source={convert:EnumBindingSource {x:Type models:MySize}}}"
+                                      SelectedItem="{Binding UISize,
+                                                             Source={x:Static config:UserSettings.Setting}}"
+                                      Style="{StaticResource SettingsComboBox}" />
+
+                            <Label Grid.Row="4" Grid.Column="0"
+                                   VerticalAlignment="Center"
+                                   Content="{DynamicResource SettingsItem_AccentColor}" />
+                            <ComboBox Grid.Row="4" Grid.Column="2"
                                       ItemsSource="{Binding Source={convert:EnumBindingSource {x:Type models:AccentColor}}}"
                                       MaxDropDownHeight="300"
                                       SelectedItem="{Binding PrimaryColor,
                                                              Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
+                                      Style="{StaticResource SettingsComboBox}" />
 
-                            <Label Grid.Row="3" Grid.Column="0"
+                            <Label Grid.Row="5" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_DisplayFont}" />
-                            <ComboBox Grid.Row="3" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="3,0,0,3"
-                                      HorizontalAlignment="Left"
+                            <ComboBox Grid.Row="5" Grid.Column="2"
                                       ItemsSource="{Binding FontList}"
                                       SelectedValue="{Binding SelectedFont,
                                                               Source={x:Static config:UserSettings.Setting}}"
                                       SelectedValuePath="Source"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
+                                      Style="{StaticResource SettingsComboBox}" />
 
-                            <Label Grid.Row="4" Grid.Column="0"
+                            <Label Grid.Row="6" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_DisplayFontSize}" />
-                            <materialDesign:NumericUpDown Grid.Row="4" Grid.Column="2"
+                            <materialDesign:NumericUpDown Grid.Row="6" Grid.Column="2"
                                                           MinWidth="200"
+                                                          Height="33"
                                                           Margin="0,4" Padding="3,0,0,0"
                                                           HorizontalAlignment="Left"
                                                           VerticalContentAlignment="Center"
@@ -351,22 +376,20 @@
                                                           Value="{Binding SelectedFontSize,
                                                                           Source={x:Static config:UserSettings.Setting}}" />
 
-                            <Label Grid.Row="5" Grid.Column="0"
+                            <Label Grid.Row="7" Grid.Column="0"
                                    VerticalAlignment="Center"
                                    Content="{DynamicResource SettingsItem_RowHeight}" />
-                            <ComboBox Grid.Row="5" Grid.Column="2"
-                                      Width="Auto" MinWidth="200"
-                                      Margin="0,3,0,0" Padding="2,0,0,3"
-                                      HorizontalAlignment="Left"
+                            <ComboBox Grid.Row="7" Grid.Column="2"
+                                      Margin="0,-1,0,-3"
                                       ItemsSource="{Binding Source={convert:EnumBindingSource {x:Type models:Spacing}}}"
                                       SelectedItem="{Binding RowSpacing,
                                                              Source={x:Static config:UserSettings.Setting}}"
-                                      Style="{StaticResource MaterialDesignComboBox}" />
+                                      Style="{StaticResource SettingsComboBox}" />
                         </Grid>
                         <!--#endregion-->
 
                         <!--#region CheckBoxes (bottom)-->
-                        <Grid Grid.Row="1" Grid.Column="1">
+                        <Grid Grid.Row="1" Grid.Column="1" Margin="0,10,0,0">
                             <Grid.RowDefinitions>
                                 <RowDefinition Height="auto" MinHeight="38" />
                                 <RowDefinition Height="auto" MinHeight="38" />


### PR DESCRIPTION
### Support separate light/dark themes for System mode
- Added SystemLightTheme and SystemDarkTheme to UserSettings with UI and logic for selecting themes when "System" is chosen. 
- Updated MainWindowHelpers and SettingChange to apply the correct theme based on system mode and user selection. 
- Refactored SettingsPage.xaml to include ComboBoxes for light/dark theme selection, visible only in System mode, using a new SettingsComboBox style. 
- Added EnumToVisibilityConverter for conditional UI display. 
- Updated resource dictionaries and added localized strings for new options. 
- SettingsViewModel now exposes SystemThemeTypes for binding.