### PR TITLE
Refactor logging for accuracy

### DIFF
--- a/WUView/Models/WUpdate.cs
+++ b/WUView/Models/WUpdate.cs
@@ -34,7 +34,7 @@ public partial class WUpdate : ObservableObject
     private string? _operation;
 
     [ObservableProperty]
-    private string? _supportURL;
+    private string _supportURL = string.Empty;
     #endregion Properties from WUApi
 
     #region Properties from Event Log

--- a/WUView/ViewModels/MainViewModel.cs
+++ b/WUView/ViewModels/MainViewModel.cs
@@ -33,8 +33,7 @@ internal sealed class MainViewModel : ObservableObject
     /// </summary>
     private static void GetListOfUpdates()
     {
-        Stopwatch sw = new();
-        sw.Start();
+        Stopwatch sw = Stopwatch.StartNew();
         IUpdateSession updateSession = new();
         IUpdateSearcher updateSearcher = updateSession.CreateUpdateSearcher();
         int count = updateSearcher.GetTotalHistoryCount();
@@ -70,17 +69,17 @@ internal sealed class MainViewModel : ObservableObject
                         Operation = OperationHelper.TranslateOperation(hist.Operation),
                         UpdateID = hist.UpdateIdentity.UpdateID,
                         Description = hist.Description ?? string.Empty,
-                        // ReSharper disable once NullCoalescingConditionIsAlwaysNotNullAccordingToAPIContract
-                        SupportURL = hist.SupportUrl ?? string.Empty,
+                        SupportURL = hist.SupportUrl,
                         ELDescription = FindEventLogs(kbNum)
                     };
                     UpdatesFullList.Add(update);
-                    if (hist.HResult != 0 && UserSettings.Setting.ShowLogWarnings)
+                    if (hist.UnmappedResultCode != 0 && UserSettings.Setting.ShowLogWarnings)
                     {
                         string operation = update.Operation.Replace("uo", "");
-                        string HResultHex = string.Format(CultureInfo.InvariantCulture, $"0x{int.Parse(update.HResult, CultureInfo.InvariantCulture):X8}");
-                        _log.Warn($"KB: {update.KBNum,-10} Date: {update.Date,-23} HResult: {HResultHex,-10} " +
-                                 $" Operation: {operation,-12}  UpdateID: {update.UpdateID}");
+                        int hResultValue = hist.UnmappedResultCode;
+                        string hResultHex = $"0x{hResultValue:X8}";
+                        _log.Warn($"KB: {update.KBNum,-10} Date: {update.Date,-23} HResult: {hResultHex,-10} " +
+                                 $" Operation: {operation,-12}  UpdateID: {update.UpdateID}  Title: {update.Title}");
                     }
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Refactor update model and logging for null-safety and prevent false positives in log.

- WUpdate._supportURL is now always a non-null empty string.
- Stopwatch in MainViewModel uses Stopwatch.StartNew() for clarity.
- SupportURL mapping no longer uses null-coalescing; always non-null.
- Logging checks now use UnmappedResultCode, not HResult.
- Log messages include update Title and hex UnmappedResultCode.