### PR TITLE
Refactor AppInfo, add Architecture property

### DIFF
--- a/WUView/Helpers/AppInfo.cs
+++ b/WUView/Helpers/AppInfo.cs
@@ -8,29 +8,9 @@ namespace WUView.Helpers;
 internal static class AppInfo
 {
     /// <summary>
-    /// Returns the operating system description e.g. Microsoft Windows 10.0.19044
+    /// Returns the process architecture e.g. X64, Arm64, etc.
     /// </summary>
-    public static string OsPlatform => RuntimeInformation.OSDescription;
-
-    /// <summary>
-    /// Returns the framework name
-    /// </summary>
-    public static string? Framework => Assembly.GetEntryAssembly()?.GetCustomAttribute<TargetFrameworkAttribute>()?.FrameworkName;
-
-    /// <summary>
-    /// Returns the framework description
-    /// </summary>
-    public static string RuntimeVersion => RuntimeInformation.FrameworkDescription;
-
-    /// <summary>
-    ///  Returns the version number in Major.Minor.Build format
-    /// </summary>
-    private static string TitleVersion => Assembly.GetEntryAssembly()!.GetName().Version!.ToString()[..Assembly.GetEntryAssembly()!.GetName().Version!.ToString().LastIndexOf('.')];
-
-    /// <summary>
-    /// Returns the file version
-    /// </summary>
-    public static string AppFileVersion => (Assembly.GetEntryAssembly()!.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version) ?? "missing";
+    public static string Architecture => RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant();
 
     /// <summary>
     /// Returns the full version number as String
@@ -58,28 +38,9 @@ internal static class AppInfo
     public static string AppName => (Assembly.GetEntryAssembly()!.GetName().Name) ?? "missing";
 
     /// <summary>
-    /// Returns the app's name with the extension
-    /// </summary>
-    public static string AppExeName => Path.GetFileName(AppPath);
-
-    /// <summary>
-    /// Returns the app's full name (name, version, culture, etc.)
-    /// </summary>
-    public static string AppFullName => Assembly.GetEntryAssembly()!.GetName().FullName;
-
-    /// <summary>
-    /// Returns the Company Name from the Assembly info
-    /// </summary>
-    public static string AppCompany => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).CompanyName ?? "missing";
-
-    /// <summary>
-    /// Returns the Author from the Assembly info
-    /// </summary>
-    public static string AppDescription => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).FileDescription ?? "missing";
-
-    /// <summary>
     /// Returns the product version from the Assembly info
     /// </summary>
+    // Don't be fooled by 0 references to this property. It is used in the About window.
     public static string AppProductVersion => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).ProductVersion ?? "missing";
 
     /// <summary>
@@ -93,45 +54,22 @@ internal static class AppInfo
     public static string AppProduct => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).ProductName ?? "missing";
 
     /// <summary>
-    /// Returns the File Name from the Assembly info
-    /// </summary>
-    public static string AppFileName => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly()!.Location).FileName;
-
-    /// <summary>
-    /// Combines the product name with the title version.
-    /// </summary>
-    /// <value>
-    /// String in the format: AppName - 0.0.1
-    /// </value>
-    public static string ToolTipVersion => $"{AppProduct} - {TitleVersion}";
-
-    /// <summary>
-    /// Returns the Process Name
-    /// </summary>
-    public static string AppProcessName => Process.GetCurrentProcess().ProcessName;
-
-    /// <summary>
     /// Returns the Process ID as Int
     /// </summary>
     public static int AppProcessID => Environment.ProcessId;
 
     /// <summary>
-    /// Returns the Process Start Time as DateTime
-    /// </summary>
-    public static DateTime AppProcessStart => Process.GetCurrentProcess().StartTime;
-
-    /// <summary>
-    /// Returns the Process MainModule
-    /// </summary>
-    public static string AppProcessMainModule => Process.GetCurrentProcess().MainModule!.ModuleName;
-
-    /// <summary>
-    /// The CLR version
-    /// </summary>
-    public static string CLRVersion => Environment.Version.ToString();
-
-    /// <summary>
     /// True if running as administrator
     /// </summary>
     public static bool IsAdmin => new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
+
+    /// <summary>
+    /// Returns the operating system description e.g. Microsoft Windows 10.0.19044
+    /// </summary>
+    public static string OsPlatform => RuntimeInformation.OSDescription;
+
+    /// <summary>
+    /// Returns the framework description
+    /// </summary>
+    public static string RuntimeVersion => RuntimeInformation.FrameworkDescription;
 }

--- a/WUView/Helpers/MainWindowHelpers.cs
+++ b/WUView/Helpers/MainWindowHelpers.cs
@@ -126,6 +126,7 @@ internal static class MainWindowHelpers
         _log.Debug($"{AppInfo.AppName} Commit date: {BuildInfo.CommitDateStringUtc} - {BuildInfo.CommitDateStringLocal}");
         _log.Debug($"{AppInfo.AppName} Commit ID: {BuildInfo.CommitIDString} ");
         _log.Debug($"{AppInfo.AppName} Process ID: {AppInfo.AppProcessID}");
+        _log.Debug($"{AppInfo.AppName} App architecture: {AppInfo.Architecture}");
         if (!string.IsNullOrEmpty(BuildInfo.Prerelease))
         {
             _log.Warn($"{AppInfo.AppName} is a prerelease version: {BuildInfo.Prerelease}");

--- a/WUView/Views/AboutPage.xaml
+++ b/WUView/Views/AboutPage.xaml
@@ -83,11 +83,15 @@
 
                 <TextBlock Grid.Row="1" Grid.Column="0"
                            Text="{DynamicResource About_Version}" />
-                <TextBlock Grid.Row="1" Grid.Column="2"
+                <StackPanel Grid.Row="1" Grid.Column="2"
+                            Orientation="Horizontal">
+                    <TextBlock 
                            Text="{x:Static buildinfo:BuildInfo.VersionString}"
                            TextWrapping="Wrap"
                            ToolTip="{x:Static helpers:AppInfo.AppProductVersion}"
                            ToolTipService.Placement="Top" />
+                    <TextBlock Text="{Binding Source={x:Static helpers:AppInfo.Architecture}, StringFormat='({0})'}" Margin="10,0,0,0" />
+                </StackPanel>
 
                 <TextBlock Grid.Row="2" Grid.Column="0"
                            Text="{DynamicResource About_CreatedBy}" />


### PR DESCRIPTION
Refactor AppInfo, add Architecture property

- Removed unused properties from AppInfo and introduced the Architecture property to expose process architecture in lowercase.
- Restored OsPlatform and RuntimeVersion properties.
- Updated MainWindowHelpers to log architecture and modified AboutPage.xaml to display version and architecture together.